### PR TITLE
Fix position of div #presentation, beacause on firefox the window scroll 

### DIFF
--- a/presi.js
+++ b/presi.js
@@ -41,6 +41,8 @@ $(window).load(function () {
     sh_highlightDocument();
     
     updateInfo();
+
+    $('#presentation').css('position','fixed');
     
     $(window).keydown(function(event) {
       var key = event.keyCode;


### PR DESCRIPTION
Fix position of div #presentation, beacause on firefox the window scroll and when we have numerous diapos the title go out of screen
